### PR TITLE
Support simple Hg and Git storages

### DIFF
--- a/lib/backup.rb
+++ b/lib/backup.rb
@@ -43,6 +43,7 @@ module Backup
     autoload :Ninefold,   File.join(STORAGE_PATH, 'ninefold')
     autoload :Dropbox,    File.join(STORAGE_PATH, 'dropbox')
     autoload :FTP,        File.join(STORAGE_PATH, 'ftp')
+    autoload :SSHBase,    File.join(STORAGE_PATH, 'ssh_base')
     autoload :SFTP,       File.join(STORAGE_PATH, 'sftp')
     autoload :SCP,        File.join(STORAGE_PATH, 'scp')
     autoload :RSync,      File.join(STORAGE_PATH, 'rsync')

--- a/lib/backup.rb
+++ b/lib/backup.rb
@@ -46,6 +46,9 @@ module Backup
     autoload :SSHBase,    File.join(STORAGE_PATH, 'ssh_base')
     autoload :SFTP,       File.join(STORAGE_PATH, 'sftp')
     autoload :SCP,        File.join(STORAGE_PATH, 'scp')
+    autoload :SCMBase,    File.join(STORAGE_PATH, 'scm_base')
+    autoload :Git,        File.join(STORAGE_PATH, 'git')
+    autoload :Hg,         File.join(STORAGE_PATH, 'hg')
     autoload :RSync,      File.join(STORAGE_PATH, 'rsync')
     autoload :Local,      File.join(STORAGE_PATH, 'local')
   end

--- a/lib/backup/config/dsl.rb
+++ b/lib/backup/config/dsl.rb
@@ -30,7 +30,7 @@ module Backup
               ['MySQL', 'PostgreSQL', 'MongoDB', 'Redis', 'Riak', 'OpenLDAP'],
               # Storages
               ['S3', 'CloudFiles', 'Ninefold', 'Dropbox', 'FTP',
-              'SFTP', 'SCP', 'RSync', 'Local'],
+              'SFTP', 'SCP', 'Git', 'Hg', 'RSync', 'Local'],
               # Compressors
               ['Gzip', 'Bzip2', 'Custom', 'Pbzip2', 'Lzma'],
               # Encryptors

--- a/lib/backup/model.rb
+++ b/lib/backup/model.rb
@@ -322,12 +322,12 @@ module Backup
     # Once complete, the temporary folder used during packaging is removed.
     def package!
       Packager.package!(self)
-      Cleaner.remove_packaging(self)
     end
 
     ##
     # Removes the final package file(s) once all configured Storages have run.
     def clean!
+      Cleaner.remove_packaging(self)
       Cleaner.remove_package(package)
     end
 

--- a/lib/backup/storage/git.rb
+++ b/lib/backup/storage/git.rb
@@ -23,6 +23,10 @@ module Backup
       def cmd
         "cd '#{remote_path}' && #{utility :git}"
       end
+
+      def excludes
+        ['.git']
+      end
     end
   end
 end

--- a/lib/backup/storage/git.rb
+++ b/lib/backup/storage/git.rb
@@ -1,0 +1,29 @@
+# encoding: utf-8
+
+module Backup
+  module Storage
+    class Git < SCMBase
+
+      protected
+
+      def init_repo ssh
+        super
+        ssh.exec! "#{cmd} config --global user.name 'backup'"
+        ssh.exec! "#{cmd} config --global user.email 'backup@#{Config.hostname}'"
+        ssh.exec! "#{cmd} init"
+      end
+
+      def commit ssh
+        filenames.each do |dir|
+          ssh.exec! "#{self.cmd} add #{dir}"
+        end
+        ssh.exec! "#{cmd} commit -m 'backup #{self.package.time}'"
+      end
+
+      def cmd
+        "cd '#{remote_path}' && #{utility :git}"
+      end
+    end
+  end
+end
+

--- a/lib/backup/storage/git.rb
+++ b/lib/backup/storage/git.rb
@@ -6,14 +6,14 @@ module Backup
 
       protected
 
-      def init_repo ssh
+      def init_repo(ssh)
         super
         ssh.exec! "#{cmd} config --global user.name 'backup'"
         ssh.exec! "#{cmd} config --global user.email 'backup@#{Config.hostname}'"
         ssh.exec! "#{cmd} init"
       end
 
-      def commit ssh
+      def commit(ssh)
         filenames.each do |dir|
           ssh.exec! "#{self.cmd} add #{dir}"
         end

--- a/lib/backup/storage/hg.rb
+++ b/lib/backup/storage/hg.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+
+module Backup
+  module Storage
+    class Hg < SCMBase
+
+      protected
+
+      def init_repo ssh
+        super
+        ssh.exec! "#{cmd} init"
+      end
+
+      def commit ssh
+        filenames.each do |dir|
+          ssh.exec! "#{self.cmd} add #{dir}"
+        end
+        ssh.exec! "#{cmd} commit -m 'backup #{package.time}'"
+      end
+
+      def cmd
+        "cd '#{remote_path}' && #{utility :hg}"
+      end
+    end
+  end
+end
+

--- a/lib/backup/storage/hg.rb
+++ b/lib/backup/storage/hg.rb
@@ -6,12 +6,12 @@ module Backup
 
       protected
 
-      def init_repo ssh
+      def init_repo(ssh)
         super
         ssh.exec! "#{cmd} init"
       end
 
-      def commit ssh
+      def commit(ssh)
         filenames.each do |dir|
           ssh.exec! "#{self.cmd} add #{dir}"
         end

--- a/lib/backup/storage/hg.rb
+++ b/lib/backup/storage/hg.rb
@@ -21,6 +21,10 @@ module Backup
       def cmd
         "cd '#{remote_path}' && #{utility :hg}"
       end
+
+      def excludes
+        ['.hg']
+      end
     end
   end
 end

--- a/lib/backup/storage/hg.rb
+++ b/lib/backup/storage/hg.rb
@@ -15,7 +15,7 @@ module Backup
         filenames.each do |dir|
           ssh.exec! "#{self.cmd} add #{dir}"
         end
-        ssh.exec! "#{cmd} commit -m 'backup #{package.time}'"
+        ssh.exec! "#{cmd} --config ui.username=backup commit -m 'backup #{package.time}'"
       end
 
       def cmd

--- a/lib/backup/storage/scm_base.rb
+++ b/lib/backup/storage/scm_base.rb
@@ -1,0 +1,64 @@
+# encoding: utf-8
+
+module Backup
+  module Storage
+    class SCMBase < SSHBase
+
+      include Utilities::Helpers
+
+      def initialize model, storage_id = nil
+        super
+      end
+
+      def transfer!
+        connection do |ssh|
+          self.init_repo ssh
+          self.syncer.perform!
+          self.commit ssh
+        end
+      end
+
+      def syncer
+        self.rsync
+      end
+
+      protected
+
+      def init_repo ssh
+        ssh.exec! "mkdir -p '#{ remote_path }'"
+      end
+      def commit ssh
+        raise 'Not implemented'
+      end
+
+      def filenames
+        syncer.directories.map{ |d| File.basename d }
+      end
+
+      # Reimplement to remove time from path
+      def remote_path pkg = package
+        path
+      end
+
+      def rsync
+        unless @rsync
+          @rsync = Backup::Syncer::RSync::Push.new
+          @rsync.mode = :ssh
+          @rsync.mirror = true
+          @rsync.host = self.ip
+          @rsync.port = self.port
+          @rsync.ssh_user = self.username
+          @rsync.path = self.remote_path
+          @rsync.add File.join(Config.tmp_path, package.trigger)
+        end
+        @rsync
+      end
+
+      # Disable cycling for an obvious reason
+      def cycle!
+      end
+
+    end
+  end
+end
+

--- a/lib/backup/storage/scm_base.rb
+++ b/lib/backup/storage/scm_base.rb
@@ -49,7 +49,9 @@ module Backup
           @rsync.port = self.port
           @rsync.ssh_user = self.username
           @rsync.path = self.remote_path
-          @rsync.add File.join(Config.tmp_path, package.trigger)
+          Dir.glob(File.join(Config.tmp_path, package.trigger, '*')).each do |dir|
+            @rsync.add dir
+          end
         end
         @rsync
       end

--- a/lib/backup/storage/scm_base.rb
+++ b/lib/backup/storage/scm_base.rb
@@ -45,6 +45,7 @@ module Backup
           @rsync = Backup::Syncer::RSync::Push.new
           @rsync.mode = :ssh
           @rsync.mirror = true
+          @rsync.compress = true
           @rsync.host = self.ip
           @rsync.port = self.port
           @rsync.ssh_user = self.username

--- a/lib/backup/storage/scm_base.rb
+++ b/lib/backup/storage/scm_base.rb
@@ -6,7 +6,7 @@ module Backup
 
       include Utilities::Helpers
 
-      def initialize model, storage_id = nil
+      def initialize(model, storage_id = nil)
         super
       end
 
@@ -24,10 +24,10 @@ module Backup
 
       protected
 
-      def init_repo ssh
+      def init_repo(ssh)
         ssh.exec! "mkdir -p '#{ remote_path }'"
       end
-      def commit ssh
+      def commit(ssh)
         raise 'Not implemented'
       end
 

--- a/lib/backup/storage/scm_base.rb
+++ b/lib/backup/storage/scm_base.rb
@@ -49,8 +49,12 @@ module Backup
           @rsync.port = self.port
           @rsync.ssh_user = self.username
           @rsync.path = self.remote_path
+
           Dir.glob(File.join(Config.tmp_path, package.trigger, '*')).each do |dir|
             @rsync.add dir
+          end
+          self.excludes.each do |dir|
+            @rsync.exclude dir
           end
         end
         @rsync
@@ -58,6 +62,10 @@ module Backup
 
       # Disable cycling for an obvious reason
       def cycle!
+      end
+
+      def excludes
+        []
       end
 
     end

--- a/lib/backup/storage/scp.rb
+++ b/lib/backup/storage/scp.rb
@@ -3,34 +3,14 @@ require 'net/scp'
 
 module Backup
   module Storage
-    class SCP < Base
+    class SCP < SSHBase
       include Storage::Cycler
-      class Error < Backup::Error; end
-
-      ##
-      # Server credentials
-      attr_accessor :username, :password, :ssh_options
-
-      ##
-      # Server IP Address and SCP port
-      attr_accessor :ip, :port
 
       def initialize(model, storage_id = nil)
         super
-
-        @port ||= 22
-        @path ||= 'backups'
-        @ssh_options ||= {}
-        path.sub!(/^~\//, '')
       end
 
       private
-
-      def connection
-        Net::SSH.start(
-          ip, username, { :password => password, :port => port }.merge(ssh_options)
-        ) {|ssh| yield ssh }
-      end
 
       def transfer!
         connection do |ssh|

--- a/lib/backup/storage/scp.rb
+++ b/lib/backup/storage/scp.rb
@@ -37,7 +37,7 @@ module Backup
           end
         end
         unless errors.empty?
-          raise Error, "Net::SSH reported the following errors:\n" +
+          raise SSHBase::Error, "Net::SSH reported the following errors:\n" +
               errors.join("\n")
         end
       end

--- a/lib/backup/storage/sftp.rb
+++ b/lib/backup/storage/sftp.rb
@@ -3,33 +3,14 @@ require 'net/sftp'
 
 module Backup
   module Storage
-    class SFTP < Base
+    class SFTP < SSHBase
       include Storage::Cycler
-
-      ##
-      # Server credentials
-      attr_accessor :username, :password, :ssh_options
-
-      ##
-      # Server IP Address and SFTP port
-      attr_accessor :ip, :port
 
       def initialize(model, storage_id = nil)
         super
-
-        @ssh_options ||= {}
-        @port        ||= 22
-        @path        ||= 'backups'
-        path.sub!(/^~\//, '')
       end
 
       private
-
-      def connection
-        Net::SFTP.start(
-          ip, username, { :password => password, :port => port }.merge(ssh_options)
-        ) {|sftp| yield sftp }
-      end
 
       def transfer!
         connection do |sftp|

--- a/lib/backup/storage/ssh_base.rb
+++ b/lib/backup/storage/ssh_base.rb
@@ -13,8 +13,6 @@ module Backup
       ##
       # Server IP Address and SFTP port
       attr_accessor :ip, :port
-      alias :host :ip
-      alias :host= :ip=
 
       def initialize model, storage_id = nil
         super

--- a/lib/backup/storage/ssh_base.rb
+++ b/lib/backup/storage/ssh_base.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+require 'net/ssh'
+
+module Backup
+  module Storage
+    class SSHBase < Base
+      class Error < Backup::Error; end
+
+      ##
+      # Server credentials
+      attr_accessor :username, :password, :ssh_options
+
+      ##
+      # Server IP Address and SFTP port
+      attr_accessor :ip, :port
+      alias :host :ip
+      alias :host= :ip=
+
+      def initialize model, storage_id = nil
+        super
+
+        @port ||= 22
+        @path ||= 'backups'
+        @ssh_options ||= {}
+        path.sub!(/^~\//, '')
+      end
+
+      protected
+
+      def connection
+        Net::SSH.start(
+          ip, username, { :password => password, :port => port }.merge(ssh_options)
+        ) {|ssh| yield ssh }
+      end
+
+    end
+  end
+end

--- a/lib/backup/storage/ssh_base.rb
+++ b/lib/backup/storage/ssh_base.rb
@@ -14,7 +14,7 @@ module Backup
       # Server IP Address and SFTP port
       attr_accessor :ip, :port
 
-      def initialize model, storage_id = nil
+      def initialize(model, storage_id = nil)
         super
 
         @port ||= 22

--- a/lib/backup/utilities.rb
+++ b/lib/backup/utilities.rb
@@ -15,6 +15,7 @@ module Backup
       sendmail exim
       send_nsca
       zabbix_sender
+      git hg
     }
 
     module DSL

--- a/lib/backup/utilities.rb
+++ b/lib/backup/utilities.rb
@@ -198,6 +198,7 @@ module Backup
         else
           raise Error, <<-EOS
             '#{ name }' failed with exit status: #{ ps.exitstatus }
+            Command: #{ command }
             STDOUT Messages: #{ out.empty? ? 'None' : "\n#{ out }" }
             STDERR Messages: #{ err.empty? ? 'None' : "\n#{ err }" }
           EOS

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -695,7 +695,6 @@ describe 'Backup::Model' do
   describe '#package!' do
     it 'should package the backup' do
       Backup::Packager.expects(:package!).in_sequence(s).with(model)
-      Backup::Cleaner.expects(:remove_packaging).in_sequence(s).with(model)
 
       model.send(:package!)
     end
@@ -703,6 +702,7 @@ describe 'Backup::Model' do
 
   describe '#clean!' do
     it 'should remove the final packaged files' do
+      Backup::Cleaner.expects(:remove_packaging).in_sequence(s).with(model)
       Backup::Cleaner.expects(:remove_package).with(model.package)
 
       model.send(:clean!)

--- a/spec/storage/git_spec.rb
+++ b/spec/storage/git_spec.rb
@@ -49,9 +49,6 @@ describe Storage::Git do
 
       storage.syncer.expects(:perform!)
 
-      connection.expects(:exec!).with(
-        "cd '#{remote_path}' && git add #{storage.package.trigger}"
-      )
       syncer_dirs.each do |dir|
         connection.expects(:exec!).with(
           "cd '#{remote_path}' && git add #{dir}"

--- a/spec/storage/git_spec.rb
+++ b/spec/storage/git_spec.rb
@@ -1,0 +1,70 @@
+# encoding: utf-8
+
+require File.expand_path('../../spec_helper.rb', __FILE__)
+
+module Backup
+describe Storage::Git do
+  let(:model)   { Model.new(:test_trigger, 'test label') }
+  let(:storage) { Storage::Git.new(model) }
+  let(:s) { sequence '' }
+
+  it_behaves_like 'a subclass of Storage::SCMBase'
+
+  describe '#transfer!' do
+    let(:connection) { mock }
+    let(:ssh) { mock }
+    let(:timestamp) { Time.now.strftime("%Y.%m.%d.%H.%M.%S") }
+    let(:remote_path) { File.join('my/path') }
+    let(:syncer_dirs) {
+      [ "tmp" ]
+    }
+
+    before do
+      Timecop.freeze
+      storage.package.time = timestamp
+      storage.ip = '123.45.678.90'
+      storage.path = 'my/path'
+      storage.syncer.add '/tmp'
+      connection.stubs(:ssh).returns(ssh)
+    end
+    after { Timecop.return }
+
+    it 'init repo and commit' do
+      storage.stubs(:utility).with(:git).returns('git')
+
+      storage.expects(:connection).yields(connection)
+
+      connection.expects(:exec!).with(
+        "mkdir -p '#{remote_path}'"
+      )
+      connection.expects(:exec!).with(
+        "cd '#{remote_path}' && git config --global user.name 'backup'"
+      )
+      connection.expects(:exec!).with(
+        "cd '#{remote_path}' && git config --global user.email 'backup@#{Config.hostname}'"
+      )
+      connection.expects(:exec!).with(
+        "cd '#{remote_path}' && git init"
+      )
+
+      storage.syncer.expects(:perform!)
+
+      connection.expects(:exec!).with(
+        "cd '#{remote_path}' && git add #{storage.package.trigger}"
+      )
+      syncer_dirs.each do |dir|
+        connection.expects(:exec!).with(
+          "cd '#{remote_path}' && git add #{dir}"
+        )
+      end
+      connection.expects(:exec!).with(
+        "cd '#{remote_path}' && git commit -m 'backup #{storage.package.time}'"
+      )
+
+      storage.send(:transfer!)
+    end
+
+  end
+
+end
+end

--- a/spec/storage/hg_spec.rb
+++ b/spec/storage/hg_spec.rb
@@ -43,16 +43,13 @@ describe Storage::Hg do
 
       storage.syncer.expects(:perform!)
 
-      connection.expects(:exec!).with(
-        "cd '#{remote_path}' && hg add #{storage.package.trigger}"
-      )
       syncer_dirs.each do |dir|
         connection.expects(:exec!).with(
           "cd '#{remote_path}' && hg add #{dir}"
         )
       end
       connection.expects(:exec!).with(
-        "cd '#{remote_path}' && hg commit -m 'backup #{storage.package.time}'"
+        "cd '#{remote_path}' && hg --config ui.username=backup commit -m 'backup #{storage.package.time}'"
       )
 
       storage.send(:transfer!)

--- a/spec/storage/hg_spec.rb
+++ b/spec/storage/hg_spec.rb
@@ -1,0 +1,64 @@
+# encoding: utf-8
+
+require File.expand_path('../../spec_helper.rb', __FILE__)
+
+module Backup
+describe Storage::Hg do
+  let(:model)   { Model.new(:test_trigger, 'test label') }
+  let(:storage) { Storage::Hg.new(model) }
+  let(:s) { sequence '' }
+
+  it_behaves_like 'a subclass of Storage::SCMBase'
+
+  describe '#transfer!' do
+    let(:connection) { mock }
+    let(:ssh) { mock }
+    let(:timestamp) { Time.now.strftime("%Y.%m.%d.%H.%M.%S") }
+    let(:remote_path) { File.join('my/path') }
+    let(:syncer_dirs) {
+      [ "tmp" ]
+    }
+
+    before do
+      Timecop.freeze
+      storage.package.time = timestamp
+      storage.ip = '123.45.678.90'
+      storage.path = 'my/path'
+      storage.syncer.add '/tmp'
+      connection.stubs(:ssh).returns(ssh)
+    end
+    after { Timecop.return }
+
+    it 'init repo and commit' do
+      storage.stubs(:utility).with(:hg).returns('hg')
+
+      storage.expects(:connection).yields(connection)
+
+      connection.expects(:exec!).with(
+        "mkdir -p '#{remote_path}'"
+      )
+      connection.expects(:exec!).with(
+        "cd '#{remote_path}' && hg init"
+      )
+
+      storage.syncer.expects(:perform!)
+
+      connection.expects(:exec!).with(
+        "cd '#{remote_path}' && hg add #{storage.package.trigger}"
+      )
+      syncer_dirs.each do |dir|
+        connection.expects(:exec!).with(
+          "cd '#{remote_path}' && hg add #{dir}"
+        )
+      end
+      connection.expects(:exec!).with(
+        "cd '#{remote_path}' && hg commit -m 'backup #{storage.package.time}'"
+      )
+
+      storage.send(:transfer!)
+    end
+
+  end
+
+end
+end

--- a/spec/storage/scp_spec.rb
+++ b/spec/storage/scp_spec.rb
@@ -102,8 +102,8 @@ describe Storage::SCP do
         expect do
           storage.send(:remove!, package)
         end.to raise_error {|err|
-          expect( err ).to be_an_instance_of Storage::SCP::Error
-          expect( err.message ).to eq "Storage::SCP::Error: " +
+          expect( err ).to be_an_instance_of Storage::SSHBase::Error
+          expect( err.message ).to eq "Storage::SSHBase::Error: " +
             "Net::SSH reported the following errors:\n" +
             "  path not found"
         }

--- a/spec/storage/scp_spec.rb
+++ b/spec/storage/scp_spec.rb
@@ -9,80 +9,8 @@ describe Storage::SCP do
   let(:s) { sequence '' }
 
   it_behaves_like 'a class that includes Config::Helpers'
-  it_behaves_like 'a subclass of Storage::Base'
+  it_behaves_like 'a subclass of Storage::SSHBase'
   it_behaves_like 'a storage that cycles'
-
-  describe '#initialize' do
-
-    it 'provides default values' do
-      expect( storage.storage_id  ).to be_nil
-      expect( storage.keep        ).to be_nil
-      expect( storage.username    ).to be_nil
-      expect( storage.password    ).to be_nil
-      expect( storage.ssh_options ).to eq({})
-      expect( storage.ip          ).to be_nil
-      expect( storage.port        ).to be 22
-      expect( storage.path        ).to eq 'backups'
-    end
-
-    it 'configures the storage' do
-      storage = Storage::SCP.new(model, :my_id) do |scp|
-        scp.keep = 2
-        scp.username    = 'my_username'
-        scp.password    = 'my_password'
-        scp.ssh_options = { :keys => ['my/key'] }
-        scp.ip          = 'my_host'
-        scp.port        = 123
-        scp.path        = 'my/path'
-      end
-
-      expect( storage.storage_id  ).to eq 'my_id'
-      expect( storage.keep        ).to be 2
-      expect( storage.username    ).to eq 'my_username'
-      expect( storage.password    ).to eq 'my_password'
-      expect( storage.ssh_options ).to eq :keys => ['my/key']
-      expect( storage.ip          ).to eq 'my_host'
-      expect( storage.port        ).to be 123
-      expect( storage.path        ).to eq 'my/path'
-    end
-
-    it 'converts a tilde path to a relative path' do
-      storage = Storage::SCP.new(model) do |scp|
-        scp.path = '~/my/path'
-      end
-      expect( storage.path ).to eq 'my/path'
-    end
-
-    it 'does not alter an absolute path' do
-      storage = Storage::SCP.new(model) do |scp|
-        scp.path = '/my/path'
-      end
-      expect( storage.path ).to eq '/my/path'
-    end
-
-  end # describe '#initialize'
-
-  describe '#connection' do
-    let(:connection) { mock }
-
-    before do
-      storage.ip = '123.45.678.90'
-      storage.username = 'my_user'
-      storage.password = 'my_pass'
-      storage.ssh_options = { :keys => ['my/key'] }
-    end
-
-    it 'yields a connection to the remote server' do
-      Net::SSH.expects(:start).with(
-        '123.45.678.90', 'my_user', :password => 'my_pass', :port => 22,
-        :keys => ['my/key']
-      ).yields(connection)
-
-      storage.send(:connection) do |scp|
-        expect( scp ).to be connection
-      end
-    end
-  end # describe '#connection'
 
   describe '#transfer!' do
     let(:connection) { mock }

--- a/spec/storage/sftp_spec.rb
+++ b/spec/storage/sftp_spec.rb
@@ -9,80 +9,8 @@ describe Storage::SFTP do
   let(:s) { sequence '' }
 
   it_behaves_like 'a class that includes Config::Helpers'
-  it_behaves_like 'a subclass of Storage::Base'
+  it_behaves_like 'a subclass of Storage::SSHBase'
   it_behaves_like 'a storage that cycles'
-
-  describe '#initialize' do
-
-    it 'provides default values' do
-      expect( storage.storage_id  ).to be_nil
-      expect( storage.keep        ).to be_nil
-      expect( storage.username    ).to be_nil
-      expect( storage.password    ).to be_nil
-      expect( storage.ssh_options ).to eq({})
-      expect( storage.ip          ).to be_nil
-      expect( storage.port        ).to be 22
-      expect( storage.path        ).to eq 'backups'
-    end
-
-    it 'configures the storage' do
-      storage = Storage::SFTP.new(model, :my_id) do |sftp|
-        sftp.keep = 2
-        sftp.username     = 'my_username'
-        sftp.password     = 'my_password'
-        sftp.ssh_options  = { :keys => ['my/key'] }
-        sftp.ip           = 'my_host'
-        sftp.port         = 123
-        sftp.path         = 'my/path'
-      end
-
-      expect( storage.storage_id  ).to eq 'my_id'
-      expect( storage.keep        ).to be 2
-      expect( storage.username    ).to eq 'my_username'
-      expect( storage.password    ).to eq 'my_password'
-      expect( storage.ssh_options ).to eq :keys => ['my/key']
-      expect( storage.ip          ).to eq 'my_host'
-      expect( storage.port        ).to be 123
-      expect( storage.path        ).to eq 'my/path'
-    end
-
-    it 'converts a tilde path to a relative path' do
-      storage = Storage::SFTP.new(model) do |sftp|
-        sftp.path = '~/my/path'
-      end
-      expect( storage.path ).to eq 'my/path'
-    end
-
-    it 'does not alter an absolute path' do
-      storage = Storage::SFTP.new(model) do |sftp|
-        sftp.path = '/my/path'
-      end
-      expect( storage.path ).to eq '/my/path'
-    end
-
-  end # describe '#initialize'
-
-  describe '#connection' do
-    let(:connection) { mock }
-
-    before do
-      storage.ip = '123.45.678.90'
-      storage.username = 'my_user'
-      storage.password = 'my_pass'
-      storage.ssh_options = { :keys => ['my/key'] }
-    end
-
-    it 'yields a connection to the remote server' do
-      Net::SFTP.expects(:start).with(
-        '123.45.678.90', 'my_user', :password => 'my_pass', :port => 22,
-        :keys => ['my/key']
-      ).yields(connection)
-
-      storage.send(:connection) do |sftp|
-        expect( sftp ).to be connection
-      end
-    end
-  end # describe '#connection'
 
   describe '#transfer!' do
     let(:connection) { mock }

--- a/spec/support/shared_examples/storage/scm_base.rb
+++ b/spec/support/shared_examples/storage/scm_base.rb
@@ -1,0 +1,30 @@
+# encoding: utf-8
+
+shared_examples 'a subclass of Storage::SCMBase' do
+
+  it_behaves_like 'a subclass of Storage::SSHBase'
+
+  describe '#transfer!' do
+    let(:connection) { mock }
+    let(:ssh) { mock }
+    let(:remote_path) { File.join('my/path') }
+
+    before do
+      storage.ip = '123.45.678.90'
+      storage.path = 'my/path'
+      connection.stubs(:ssh).returns(ssh)
+    end
+
+    it 'call abstract methods' do
+      storage.expects(:connection).yields(connection)
+
+      storage.expects(:init_repo)
+      storage.syncer.expects(:perform!)
+      storage.expects(:commit)
+
+      storage.send(:transfer!)
+    end
+
+  end
+
+end

--- a/spec/support/shared_examples/storage/ssh_base.rb
+++ b/spec/support/shared_examples/storage/ssh_base.rb
@@ -1,0 +1,81 @@
+# encoding: utf-8
+
+module Backup
+shared_examples 'a subclass of Storage::SSHBase' do
+
+  it_behaves_like 'a subclass of Storage::Base'
+
+  describe '#initialize' do
+
+    it 'provides default values' do
+      expect( storage.storage_id  ).to be_nil
+      expect( storage.keep        ).to be_nil
+      expect( storage.username    ).to be_nil
+      expect( storage.password    ).to be_nil
+      expect( storage.ssh_options ).to eq({})
+      expect( storage.ip          ).to be_nil
+      expect( storage.port        ).to be 22
+      expect( storage.path        ).to eq 'backups'
+    end
+
+    it 'configures the storage' do
+      storage = Storage::SSHBase.new(model, :my_id) do |ssh|
+        ssh.keep = 2
+        ssh.username    = 'my_username'
+        ssh.password    = 'my_password'
+        ssh.ssh_options = { :keys => ['my/key'] }
+        ssh.ip          = 'my_host'
+        ssh.port        = 123
+        ssh.path        = 'my/path'
+      end
+
+      expect( storage.storage_id  ).to eq 'my_id'
+      expect( storage.keep        ).to be 2
+      expect( storage.username    ).to eq 'my_username'
+      expect( storage.password    ).to eq 'my_password'
+      expect( storage.ssh_options ).to eq :keys => ['my/key']
+      expect( storage.ip          ).to eq 'my_host'
+      expect( storage.port        ).to be 123
+      expect( storage.path        ).to eq 'my/path'
+    end
+
+    it 'converts a tilde path to a relative path' do
+      storage = Storage::SSHBase.new(model) do |ssh|
+        ssh.path = '~/my/path'
+      end
+      expect( storage.path ).to eq 'my/path'
+    end
+
+    it 'does not alter an absolute path' do
+      storage = Storage::SSHBase.new(model) do |ssh|
+        ssh.path = '/my/path'
+      end
+      expect( storage.path ).to eq '/my/path'
+    end
+
+  end # describe '#initialize'
+
+  describe '#connection' do
+    let(:connection) { mock }
+
+    before do
+      storage.ip = '123.45.678.90'
+      storage.username = 'my_user'
+      storage.password = 'my_pass'
+      storage.ssh_options = { :keys => ['my/key'] }
+    end
+
+    it 'yields a connection to the remote server' do
+      Net::SSH.expects(:start).with(
+        '123.45.678.90', 'my_user', :password => 'my_pass', :port => 22,
+        :keys => ['my/key']
+      ).yields(connection)
+
+      storage.send(:connection) do |ssh|
+        expect( ssh ).to be connection
+      end
+    end
+  end # describe '#connection'
+
+end
+end

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -45,6 +45,8 @@ describe Backup::Utilities do
         # Syncer and Storage
         rsync   '/path/to/rsync'
         ssh     '/path/to/ssh'
+        git     '/path/to/git'
+        hg      '/path/to/hg'
 
         # Notifiers
         sendmail  '/path/to/sendmail'
@@ -342,6 +344,7 @@ describe Backup::Utilities::Helpers do
             helpers.send(:run, command)
           end.to raise_error {|err|
             err.message.should == message_head +
+              "  Command: #{command}\n" +
               "  STDOUT Messages: None\n" +
               "  STDERR Messages: None"
           }
@@ -357,6 +360,7 @@ describe Backup::Utilities::Helpers do
             helpers.send(:run, command)
           end.to raise_error {|err|
             err.message.should == message_head +
+              "  Command: #{command}\n" +
               "  STDOUT Messages: \n" +
               "  out line1\n" +
               "  out line2\n" +
@@ -374,6 +378,7 @@ describe Backup::Utilities::Helpers do
             helpers.send(:run, command)
           end.to raise_error {|err|
             err.message.should == message_head +
+              "  Command: #{command}\n" +
               "  STDOUT Messages: None\n" +
               "  STDERR Messages: \n" +
               "  err line1\n" +
@@ -391,6 +396,7 @@ describe Backup::Utilities::Helpers do
             helpers.send(:run, command)
           end.to raise_error {|err|
             err.message.should == message_head +
+              "  Command: #{command}\n" +
               "  STDOUT Messages: \n" +
               "  out line1\n" +
               "  out line2\n" +


### PR DESCRIPTION
This PR is my first backup development attempt, so it may not conform to all contribution needs.

The backup is done on `package.trigger` rather than `package.filenames`, with (git|hg) commit.

The main problem to support SCM storages is that for them the packager, compressor and splitter doesn't make any sense at all. I had made efforts to make changes in the existing code as minimal as possible. See diff.