### PR TITLE
Update json dependency

### DIFF
--- a/backup.gemspec
+++ b/backup.gemspec
@@ -71,7 +71,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'httparty', '= 0.12.0'
   gem.add_dependency 'inflecto', '= 0.0.2'
   gem.add_dependency 'ipaddress', '= 0.8.0'
-  gem.add_dependency 'json', '= 1.8.1'
+  gem.add_dependency 'json', '= 1.8.2'
   gem.add_dependency 'mail', '= 2.5.4'
   gem.add_dependency 'memoizable', '= 0.4.0'
   gem.add_dependency 'mime-types', '= 1.25.1'


### PR DESCRIPTION
Ruby 2.2.0 does not build gem json 1.8.1.
It was fixed in 1.8.2 version.

Need to update backup dependency, to make it possible to use with ruby 2.2.0