### PR TITLE
fix data dog notifier

### DIFF
--- a/lib/backup/config/dsl.rb
+++ b/lib/backup/config/dsl.rb
@@ -43,7 +43,7 @@ module Backup
               # Notifiers
               ['Mail', 'Twitter', 'Campfire', 'Prowl',
               'Hipchat', 'PagerDuty', 'Pushover', 'HttpPost', 'Nagios',
-              'Slack', 'FlowDock', 'Zabbix', 'Ses']
+              'Slack', 'FlowDock', 'Zabbix', 'Ses', 'DataDog']
             ]
           )
         end


### PR DESCRIPTION
The config DSL notifiers did not have data dog listed so even though there was a notifier for it the DataDog notification could not be used.  So I fixed it.  