### PR TITLE
update fog to v1.28.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.0)
+    CFPropertyList (2.3.1)
     addressable (2.3.5)
     atomic (1.1.14)
     aws-ses (0.5.0)
@@ -21,7 +21,7 @@ GEM
     dropbox-sdk (1.5.1)
       json
     equalizer (0.0.9)
-    excon (0.44.1)
+    excon (0.44.4)
     faraday (0.8.8)
       multipart-post (~> 1.2.0)
     ffi (1.9.3)
@@ -30,7 +30,7 @@ GEM
     flowdock (0.4.0)
       httparty (~> 0.7)
       multi_json
-    fog (1.27.0)
+    fog (1.28.0)
       fog-atmos
       fog-aws (~> 0.0)
       fog-brightbox (~> 0.4)
@@ -39,6 +39,7 @@ GEM
       fog-json
       fog-profitbricks
       fog-radosgw (>= 0.0.2)
+      fog-riakcs
       fog-sakuracloud (>= 0.0.4)
       fog-serverlove
       fog-softlayer
@@ -52,7 +53,7 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (0.1.0)
+    fog-aws (0.1.1)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
@@ -61,7 +62,7 @@ GEM
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.28.0)
+    fog-core (1.29.0)
       builder
       excon (~> 0.38)
       formatador (~> 0.2)
@@ -73,7 +74,7 @@ GEM
       fog-xml
     fog-json (1.0.0)
       multi_json (~> 1.0)
-    fog-profitbricks (0.0.1)
+    fog-profitbricks (0.0.2)
       fog-core
       fog-xml
       nokogiri
@@ -81,19 +82,23 @@ GEM
       fog-core (>= 1.21.0)
       fog-json
       fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
     fog-sakuracloud (1.0.0)
       fog-core
       fog-json
     fog-serverlove (0.1.1)
       fog-core
       fog-json
-    fog-softlayer (0.4.0)
+    fog-softlayer (0.4.1)
       fog-core
       fog-json
     fog-storm_on_demand (0.1.0)
       fog-core
       fog-json
-    fog-terremark (0.0.3)
+    fog-terremark (0.0.4)
       fog-core
       fog-xml
     fog-vmfusion (0.0.1)

--- a/backup.gemspec
+++ b/backup.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'faraday', '= 0.8.8'
   gem.add_dependency 'fission', '= 0.5.0'
   gem.add_dependency 'flowdock', '= 0.4.0'
-  gem.add_dependency 'fog', '= 1.27.0'
+  gem.add_dependency 'fog', '= 1.28.0'
   gem.add_dependency 'fog-atmos', '= 0.1.0'
   gem.add_dependency 'fog-aws', '= 0.1.0'
   gem.add_dependency 'fog-brightbox', '= 0.7.1'


### PR DESCRIPTION
Fog 1.27.0 had a duplicate key in a hash (https://github.com/fog/fog/commit/b8981c1d90d2954aca29fbebd30c789cfb83f08e) which created a warning on Ruby 2.2 every time backup ran.